### PR TITLE
feat: Create initial Terraform network and cache modules

### DIFF
--- a/terraform/modules/cache/.placeholder
+++ b/terraform/modules/cache/.placeholder
@@ -1,0 +1,1 @@
+# This is a placeholder file to create the cache directory.

--- a/terraform/modules/cache/main.tf
+++ b/terraform/modules/cache/main.tf
@@ -1,0 +1,29 @@
+# main.tf for cache module
+
+resource "aws_elasticache_subnet_group" "main" {
+  name       = "${var.project_name}-${var.environment}-cache-subnet-group"
+  subnet_ids = var.private_subnet_ids # This will come from the network module
+
+  tags = {
+    Name        = "${var.project_name}-${var.environment}-cache-subnet-group"
+    Project     = var.project_name
+    Environment = var.environment
+  }
+}
+
+resource "aws_elasticache_cluster" "main" {
+  cluster_id           = "${var.project_name}-${var.environment}-redis-cluster"
+  engine               = "redis"
+  node_type            = var.cache_node_type
+  num_cache_nodes      = var.cache_num_nodes
+  engine_version       = var.cache_engine_version
+  parameter_group_name = var.cache_parameter_group_name
+  subnet_group_name    = aws_elasticache_subnet_group.main.name
+  security_group_ids   = var.cache_security_group_ids # This will likely include the main_security_group_id from the network module
+
+  tags = {
+    Name        = "${var.project_name}-${var.environment}-redis-cluster"
+    Project     = var.project_name
+    Environment = var.environment
+  }
+}

--- a/terraform/modules/cache/outputs.tf
+++ b/terraform/modules/cache/outputs.tf
@@ -1,0 +1,21 @@
+# outputs.tf for cache module
+
+output "redis_cluster_id" {
+  description = "The ID of the ElastiCache Redis cluster."
+  value       = aws_elasticache_cluster.main.id
+}
+
+output "redis_primary_endpoint_address" {
+  description = "The address of the primary endpoint for the ElastiCache Redis cluster."
+  value       = aws_elasticache_cluster.main.cache_nodes[0].address
+}
+
+output "redis_cluster_engine" {
+  description = "The engine of the ElastiCache cluster."
+  value       = aws_elasticache_cluster.main.engine
+}
+
+output "redis_reader_endpoint_address" {
+  description = "The address of the reader endpoint for the ElastiCache Redis cluster. May be null if not applicable (e.g. single node cluster)."
+  value       = aws_elasticache_cluster.main.reader_endpoint_address
+}

--- a/terraform/modules/cache/variables.tf
+++ b/terraform/modules/cache/variables.tf
@@ -1,0 +1,49 @@
+# variables.tf for cache module
+
+variable "project_name" {
+  description = "Project name for tagging resources."
+  type        = string
+  default     = "my-project"
+}
+
+variable "environment" {
+  description = "Environment name for tagging resources (e.g., dev, staging, prod)."
+  type        = string
+  default     = "dev"
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs where the ElastiCache cluster will be deployed."
+  type        = list(string)
+  # No default, this must be provided from the network module.
+}
+
+variable "cache_security_group_ids" {
+  description = "List of security group IDs for the ElastiCache cluster."
+  type        = list(string)
+  # No default, this must be provided (likely from the network module).
+}
+
+variable "cache_node_type" {
+  description = "Node type for the ElastiCache cluster (e.g., cache.t3.micro)."
+  type        = string
+  default     = "cache.t3.micro"
+}
+
+variable "cache_num_nodes" {
+  description = "Number of nodes in the ElastiCache cluster."
+  type        = number
+  default     = 1
+}
+
+variable "cache_engine_version" {
+  description = "Engine version for the ElastiCache cluster (e.g., '6.x')."
+  type        = string
+  default     = "6.x"
+}
+
+variable "cache_parameter_group_name" {
+  description = "Parameter group name for the ElastiCache cluster (e.g., 'default.redis6.x')."
+  type        = string
+  default     = "default.redis6.x"
+}

--- a/terraform/modules/network/.placeholder
+++ b/terraform/modules/network/.placeholder
@@ -1,0 +1,1 @@
+# This is a placeholder file to create the network directory.

--- a/terraform/modules/network/main.tf
+++ b/terraform/modules/network/main.tf
@@ -1,0 +1,95 @@
+# main.tf for network module
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16" # Placeholder CIDR block
+
+  tags = {
+    Name = "main-vpc"
+  }
+}
+
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.1.0/24" # Placeholder CIDR block
+  availability_zone = "us-east-1a"  # Placeholder AZ
+
+  tags = {
+    Name = "private-subnet-a"
+  }
+}
+
+resource "aws_subnet" "private_b" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.2.0/24" # Placeholder CIDR block
+  availability_zone = "us-east-1b"  # Placeholder AZ
+
+  tags = {
+    Name = "private-subnet-b"
+  }
+}
+
+resource "aws_subnet" "public_a" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.101.0/24" # Placeholder CIDR block
+  availability_zone       = "us-east-1a"    # Placeholder AZ
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "public-subnet-a"
+  }
+}
+
+resource "aws_subnet" "public_b" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.102.0/24" # Placeholder CIDR block
+  availability_zone       = "us-east-1b"    # Placeholder AZ
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "public-subnet-b"
+  }
+}
+
+resource "aws_security_group" "general" {
+  name        = "general-sg"
+  description = "General use security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"] # Allow all inbound traffic (adjust as needed)
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"] # Allow all outbound traffic
+  }
+
+  tags = {
+    Name = "general-sg"
+  }
+}
+
+resource "aws_vpc_endpoint" "dynamodb" {
+  vpc_id          = aws_vpc.main.id
+  service_name    = "com.amazonaws.us-east-1.dynamodb" # Adjust region as needed
+  vpc_endpoint_type = "Gateway"
+
+  tags = {
+    Name = "dynamodb-vpc-endpoint"
+  }
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id          = aws_vpc.main.id
+  service_name    = "com.amazonaws.us-east-1.s3" # Adjust region as needed
+  vpc_endpoint_type = "Gateway"
+
+  tags = {
+    Name = "s3-vpc-endpoint"
+  }
+}

--- a/terraform/modules/network/outputs.tf
+++ b/terraform/modules/network/outputs.tf
@@ -1,0 +1,21 @@
+# outputs.tf for network module
+
+output "vpc_id" {
+  description = "The ID of the VPC."
+  value       = aws_vpc.main.id
+}
+
+output "private_subnet_ids" {
+  description = "List of IDs of the private subnets."
+  value       = [aws_subnet.private_a.id, aws_subnet.private_b.id]
+}
+
+output "public_subnet_ids" {
+  description = "List of IDs of the public subnets."
+  value       = [aws_subnet.public_a.id, aws_subnet.public_b.id]
+}
+
+output "main_security_group_id" {
+  description = "The ID of the main security group."
+  value       = aws_security_group.general.id
+}

--- a/terraform/modules/network/variables.tf
+++ b/terraform/modules/network/variables.tf
@@ -1,0 +1,37 @@
+# variables.tf for network module
+
+variable "aws_region" {
+  description = "AWS region for the resources."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "vpc_cidr_block" {
+  description = "CIDR block for the VPC."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "private_subnet_cidrs" {
+  description = "List of CIDR blocks for private subnets."
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "public_subnet_cidrs" {
+  description = "List of CIDR blocks for public subnets."
+  type        = list(string)
+  default     = ["10.0.101.0/24", "10.0.102.0/24"]
+}
+
+variable "availability_zones" {
+  description = "List of availability zones for subnets."
+  type        = list(string)
+  default     = ["us-east-1a", "us-east-1b"]
+}
+
+variable "project_name" {
+  description = "Project name for tagging resources."
+  type        = string
+  default     = "my-project"
+}


### PR DESCRIPTION
This commit introduces the basic structure and resource definitions for the network and cache Terraform modules as outlined in the README.md.

Created:
- `terraform/modules/network/`:
    - `main.tf`: Defines VPC, private/public subnets, security group, and VPC endpoints for DynamoDB and S3.
    - `variables.tf`: Defines variables for region, CIDRs, AZs, and project name.
    - `outputs.tf`: Defines outputs for VPC ID, subnet IDs, and security group ID.
- `terraform/modules/cache/`:
    - `main.tf`: Defines ElastiCache Redis cluster and subnet group.
    - `variables.tf`: Defines variables for project name, environment, subnet IDs, security group IDs, node type, engine version, and parameter group name.
    - `outputs.tf`: Defines outputs for Redis cluster ID, primary/reader endpoint addresses, and engine.

The root `terraform/main.tf` has not yet been updated to utilize these new modules. I will address this in a subsequent step.